### PR TITLE
Add StartOffset and EndOffset to RecognitionResult type struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AudDMusic/audd-go
+module github.com/veritone/audd-go
 
 go 1.15
 

--- a/metadata.go
+++ b/metadata.go
@@ -19,6 +19,8 @@ type RecognitionResult struct {
 	Score       int                     `json:"score,omitempty"`
 	SongLength  string                  `json:"song_length,omitempty"`
 	AudioID     int                     `json:"audio_id,omitempty"`
+	StartOffset int                     `json:"start_offset,omitempty"`
+	EndOffset   int                     `json:"end_offset,omitempty"`
 }
 
 type RecognitionEnterpriseResult struct {


### PR DESCRIPTION
Ignore package name update in the fork.

When comparing enterprise response we noticed that the start and end offsets were not part of the `RecognitionResult` struct.

Cheers